### PR TITLE
Improve inject functionality

### DIFF
--- a/lxdfile.cabal
+++ b/lxdfile.cabal
@@ -28,6 +28,7 @@ library
                      , Language.LXDFile.Version
                      , System.LXD.LXDFile
                      , System.LXD.LXDFile.Build
+                     , System.LXD.LXDFile.Inject
                      , System.LXD.LXDFile.Launch
                      , System.LXD.LXDFile.ScriptAction
                      , System.LXD.LXDFile.Utils.Monad

--- a/src/System/LXD/LXDFile.hs
+++ b/src/System/LXD/LXDFile.hs
@@ -1,8 +1,10 @@
 -- | Module to interact with lxdfiles.
 module System.LXD.LXDFile (
   build
+, inject
 , launch
 ) where
 
 import System.LXD.LXDFile.Build (build)
+import System.LXD.LXDFile.Inject (inject)
 import System.LXD.LXDFile.Launch (launch)

--- a/src/System/LXD/LXDFile/Build.hs
+++ b/src/System/LXD/LXDFile/Build.hs
@@ -27,7 +27,7 @@ import Turtle (Fold(..), fold, echo, inproc, rm, format, sleep, (%))
 import qualified Turtle as R
 
 import Language.LXDFile (LXDFile(..))
-import System.LXD.LXDFile.ScriptAction (HasContext(..), scriptActions, runScriptAction, tmpfile)
+import System.LXD.LXDFile.ScriptAction (scriptActions, runScriptAction, tmpfile)
 import System.LXD.LXDFile.Utils.Monad (orThrowM)
 import System.LXD.LXDFile.Utils.Shell (HasContainer(..), lxc, lxcExec, lxcFilePush)
 
@@ -47,7 +47,7 @@ build lxdfile'@LXDFile{..} imageName' context' = do
         echo $ "Building " <> pack imageName' <> " in " <> container
         sleep 5.0
 
-        mapM_ runScriptAction $ scriptActions actions
+        mapM_ (runScriptAction context') $ scriptActions actions
         includeLXDFile
 
         echo $ "Stopping " <> container
@@ -76,6 +76,3 @@ includeLXDFile = do
 
 instance MonadReader BuildCtx m => HasContainer m where
     askContainer = buildContainer <$> ask
-
-instance MonadReader BuildCtx m => HasContext m where
-    askContext = context <$> ask

--- a/src/System/LXD/LXDFile/Build.hs
+++ b/src/System/LXD/LXDFile/Build.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | Build LXD images using lxdfiles.
 module System.LXD.LXDFile.Build (
   build
@@ -12,7 +10,7 @@ import Prelude hiding (writeFile)
 
 import Control.Monad.Except (MonadError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (MonadReader, runReaderT, ask)
+import Control.Monad.Reader (MonadReader, ReaderT, runReaderT, ask)
 
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString.Lazy (writeFile)
@@ -29,7 +27,7 @@ import qualified Turtle as R
 import Language.LXDFile (LXDFile(..))
 import System.LXD.LXDFile.ScriptAction (scriptActions, runScriptAction, tmpfile)
 import System.LXD.LXDFile.Utils.Monad (orThrowM)
-import System.LXD.LXDFile.Utils.Shell (HasContainer(..), lxc, lxcExec, lxcFilePush)
+import System.LXD.LXDFile.Utils.Shell (Container, lxc, lxcExec, lxcFilePush)
 
 data BuildCtx = BuildCtx { lxdfile :: LXDFile
                          , imageName :: String
@@ -47,7 +45,7 @@ build lxdfile'@LXDFile{..} imageName' context' = do
         echo $ "Building " <> pack imageName' <> " in " <> container
         sleep 5.0
 
-        mapM_ (runScriptAction context') $ scriptActions actions
+        mapM_ (flip runReaderT container . runScriptAction context') $ scriptActions actions
         includeLXDFile
 
         echo $ "Stopping " <> container
@@ -70,9 +68,9 @@ includeLXDFile :: (MonadIO m, MonadError String m, MonadReader BuildCtx m) => m 
 includeLXDFile = do
     file <- tmpfile "lxdfile-metadata-lxdfile"
     ask >>= liftIO . writeFile file . encodePretty . lxdfile
-    lxcExec ["mkdir", "-p", "/etc/lxdfile"]
-    lxcFilePush "0644" file "/etc/lxdfile/lxdfile"
+    run $ lxcExec ["mkdir", "-p", "/etc/lxdfile"]
+    run $ lxcFilePush "0644" file "/etc/lxdfile/lxdfile"
     rm (decodeString file)
 
-instance MonadReader BuildCtx m => HasContainer m where
-    askContainer = buildContainer <$> ask
+run :: MonadReader BuildCtx m => ReaderT Container m a -> m a
+run x = buildContainer <$> ask >>= runReaderT x

--- a/src/System/LXD/LXDFile/Inject.hs
+++ b/src/System/LXD/LXDFile/Inject.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+module System.LXD.LXDFile.Inject (
+  InitScriptContext(..)
+, inject
+, runInitScript
+) where
+
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (MonadReader, runReaderT)
+
+import Data.Text (pack)
+
+import Turtle (echo)
+
+import Language.LXDFile.InitScript (InitScript(..))
+import System.LXD.LXDFile.ScriptAction (scriptActions, runScriptAction)
+import System.LXD.LXDFile.Utils.Shell (Container)
+
+data InitScriptContext = InitScriptContext { initScript :: InitScript
+                                           , context :: FilePath }
+
+inject :: (MonadIO m, MonadError String m) => String -> [InitScriptContext] -> m ()
+inject container' scripts' = do
+    mapM_ (flip runReaderT container . runInitScript) scripts'
+    echo "Successfully injected scripts"
+  where
+    container = pack container'
+
+runInitScript :: (MonadIO m, MonadError String m, MonadReader Container m) => InitScriptContext -> m ()
+runInitScript s = mapM_ run' actions'
+  where
+    actions' = scriptActions . actions $ initScript s
+    run' = runScriptAction (context s)

--- a/src/System/LXD/LXDFile/ScriptAction.hs
+++ b/src/System/LXD/LXDFile/ScriptAction.hs
@@ -5,6 +5,7 @@ import Control.Lens (Lens', lens, (^.), (.~), (%~))
 import Control.Monad.Except (MonadError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.State (State, evalState, modify, get)
+import Control.Monad.Reader (MonadReader)
 
 import Data.Foldable (foldlM)
 import Data.Monoid ((<>))
@@ -21,7 +22,7 @@ import System.FilePath (takeDirectory)
 
 import Language.LXDFile.Types (Action(..), Arguments(..), Source, Destination, Key, Value)
 import System.LXD.LXDFile.Utils.String (replace)
-import System.LXD.LXDFile.Utils.Shell (HasContainer(..), lxcExec, lxcFilePush)
+import System.LXD.LXDFile.Utils.Shell (Container, lxcExec, lxcFilePush)
 import System.LXD.LXDFile.Utils.Text (showT)
 
 data ScriptCtx = ScriptCtx { _currentDirectory :: FilePath
@@ -72,7 +73,7 @@ argumentsSh (ArgumentsList xs) = [pack . unwords $ map escapeArg xs]
   where
     escapeArg = replace " " "\\ " . replace "\t" "\\\t" . replace "\"" "\\\"" . replace "'" "\\'"
 
-runScriptAction :: (MonadIO m, MonadError String m, HasContainer m) => FilePath -> ScriptAction -> m ()
+runScriptAction :: (MonadIO m, MonadError String m, MonadReader Container m) => FilePath -> ScriptAction -> m ()
 runScriptAction _ (SRun ctx cmd) = do
     echo $ "RUN " <> showT cmd
     script <- makeScript

--- a/src/System/LXD/LXDFile/Utils/Shell.hs
+++ b/src/System/LXD/LXDFile/Utils/Shell.hs
@@ -3,11 +3,14 @@ module System.LXD.LXDFile.Utils.Shell where
 
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (MonadReader, ask)
 
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
 
 import Turtle (ExitCode(..), proc)
+
+type Container = Text
 
 exec :: (MonadIO m, MonadError String m) => Text -> [Text] -> Maybe Text -> m ()
 exec cmd args stdin = proc cmd args stdin' >>= toErr
@@ -20,15 +23,12 @@ exec cmd args stdin = proc cmd args stdin' >>= toErr
 lxc :: (MonadIO m, MonadError String m) => [Text] -> m ()
 lxc args = exec "lxc" args Nothing
 
-class Monad m => HasContainer m where
-    askContainer :: m Text
-
-lxcExec :: (MonadIO m, MonadError String m, HasContainer m) => [Text] -> m ()
+lxcExec :: (MonadIO m, MonadError String m, MonadReader Container m) => [Text] -> m ()
 lxcExec args = do
-    c <- askContainer
+    c <- ask
     lxc $ ["exec", "--mode=non-interactive", c, "--"] ++ args
 
-lxcFilePush :: (MonadIO m, MonadError String m, HasContainer m) => String -> FilePath -> FilePath -> m ()
+lxcFilePush :: (MonadIO m, MonadError String m, MonadReader Container m) => String -> FilePath -> FilePath -> m ()
 lxcFilePush mode src dst = do
-    c <- askContainer
+    c <- ask
     lxc ["file", "push", "--mode=" <> pack mode, pack src, c <> "/" <> pack dst]


### PR DESCRIPTION
- Contexts are now specified per init script. Each init script has its own context.
- A new command `inject` is implemented to inject init scripts into a running container for configuration purposes.